### PR TITLE
feat: suppport tokio backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "bytes",
  "ffi-convert",
  "flume",
+ "futures",
  "lazy_static",
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT License Copyright (c) 2021 Kuaishou AI Platform & DS3 Lab"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["staticlib"]
 
 [dependencies]
 nix = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1"
 bytes = "1.1"
 libc = "0.2"
 ffi-convert = "0.5"
-flume = "0.10"
+flume = { version = "0.10", features = ["async"] }
 socket2 = "0.4"
 opentelemetry = { version = "0.16", features = [
     "trace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ prometheus = { version = "0.12", features = ["push"] }
 lazy_static = "1.4"
 regex = "1.5"
 tokio = { version = "1", features = ["full"] }
+futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1"
 bytes = "1.1"
 libc = "0.2"
 ffi-convert = "0.5"
-flume = { version = "0.10", features = ["async"] }
+flume = "0.10"
 socket2 = "0.4"
 opentelemetry = { version = "0.16", features = [
     "trace",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Bagua-Net
 
 Bagua-Net is a high performance NCCL plugin for [Bagua](https://github.com/BaguaSys/bagua). By optimizing the fairness among multiple TCP streams, Bagua-Net can improve the overall throughput under TCP network by more than 30% for typical distributed learning tasks.
 
+## Requirement
+
+ - NCCL >= v2.6.4
+
 ## Quick Start
 
 ```bash
@@ -50,18 +54,18 @@ In an [end-to-end test](https://github.com/BaguaSys/examples/blob/main/benchmark
 ```
 # VGG16 on 4x8xV100 bagua-net
 Running benchmark...
-Iter #0: 3643.4 img/sec GPU
-Iter #1: 3648.4 img/sec GPU
-Iter #2: 3544.0 img/sec GPU
-Iter #3: 3656.5 img/sec GPU
-Iter #4: 3684.8 img/sec GPU
-Iter #5: 3641.1 img/sec GPU
-Iter #6: 3643.4 img/sec GPU
-Iter #7: 3590.5 img/sec GPU
-Iter #8: 3635.0 img/sec GPU
-Iter #9: 3694.8 img/sec GPU
-Img/sec per GPU: 113.7 +-2.5
-Total img/sec on 32 GPU(s): 3638.2 +-80.9
+Iter #0: 4081.0 img/sec GPU
+Iter #1: 4072.0 img/sec GPU
+Iter #2: 4106.4 img/sec GPU
+Iter #3: 4081.7 img/sec GPU
+Iter #4: 4064.8 img/sec GPU
+Iter #5: 4122.1 img/sec GPU
+Iter #6: 3857.7 img/sec GPU
+Iter #7: 4128.3 img/sec GPU
+Iter #8: 4125.5 img/sec GPU
+Iter #9: 3826.6 img/sec GPU
+Img/sec per GPU: 126.5 +-6.4
+Total img/sec on 32 GPU(s): 4046.6 +-205.2
 
 # VGG16 on 4x8xV100 baseline
 Running benchmark...
@@ -78,3 +82,5 @@ Iter #9: 2796.6 img/sec GPU
 Img/sec per GPU: 85.8 +-3.8
 Total img/sec on 32 GPU(s): 2744.9 +-122.3
 ```
+
+> As a reminder, this implementation is not good at send/recv hybrid communication with too many link relationships, such as alltoall. So if your need is to use NCCL to implement algorithms like alltoall, bagua-net is not your thing.

--- a/cc/Makefile
+++ b/cc/Makefile
@@ -1,26 +1,26 @@
 INC:= -I. -I./v4 -I./v3
 PLUGIN_SO:=libnccl-net.so
-BAGUA_NET_SO:=libbagua_net.so
+BAGUA_NET_LIB:=libbagua_net.a
 NCCL_NET_V4:=./v4/nccl_net_v4.cc
 NCCL_NET_V3:=./v3/nccl_net_v3.cc
 
-default: $(PLUGIN_SO) $(BAGUA_NET_SO)
+default: $(PLUGIN_SO) $(BAGUA_NET_LIB)
 
-$(PLUGIN_SO): bagua_net.cc $(NCCL_NET_V4) $(NCCL_NET_V3) $(BAGUA_NET_SO)
+$(PLUGIN_SO): bagua_net.cc $(NCCL_NET_V4) $(NCCL_NET_V3) $(BAGUA_NET_LIB)
 	$(CXX) -v $(INC) \
 	-std=c++17 -fPIC -shared \
 	-o $@ $^ \
-	-L. -l:$(BAGUA_NET_SO)
+	-L. -l:$(BAGUA_NET_LIB)
 
-$(BAGUA_NET_SO):
-	cargo build --release && cp ../target/release/$(BAGUA_NET_SO) ./$(BAGUA_NET_SO)
+$(BAGUA_NET_LIB):
+	cargo build --release && cp ../target/release/$(BAGUA_NET_LIB) ./$(BAGUA_NET_LIB)
 
 test:
 	cargo test --verbose
 
 clean:
-	rm -f $(PLUGIN_SO) $(BAGUA_NET_SO)
+	rm -f $(PLUGIN_SO) $(BAGUA_NET_LIB)
 
 tar:
-	mkdir build && mv $(PLUGIN_SO) $(BAGUA_NET_SO) build \
+	mkdir build && mv $(PLUGIN_SO) build \
 		&& tar xzf build.tar.gz

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -277,7 +277,7 @@ impl BaguaNet {
                 .parse()
                 .unwrap(),
             tokio_rt: tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(4)
+                .worker_threads(8)
                 .enable_all()
                 .build()
                 .unwrap(),

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -663,7 +663,7 @@ impl BaguaNet {
                 if task_completed {
                     send_req.trace_span.end();
                 }
-                println!("send_req.state={:?}", state);
+                // println!("send_req.state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
             SocketRequest::RecvRequest(recv_req) => {
@@ -676,7 +676,7 @@ impl BaguaNet {
                 if task_completed {
                     recv_req.trace_span.end();
                 }
-                println!("recv_req.state={:?}", state);
+                // println!("recv_req.state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
         };

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -520,6 +520,8 @@ impl BaguaNet {
             stream.read_exact(&mut stream_id[..]).unwrap();
             let stream_id = usize::from_be_bytes(stream_id);
 
+            println!("stream_id={}", stream_id);
+
             if stream_id == self.nstreams {
                 ctrl_stream = Some(stream);
             } else {

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -507,7 +507,7 @@ impl BaguaNet {
             streams_input.push(msg_sender);
         }
 
-        let (mut ctrl_stream, _addr) = match listen_comm.tcp_listener.lock().unwrap().accept() {
+        let (ctrl_stream, _addr) = match listen_comm.tcp_listener.lock().unwrap().accept() {
             Ok(listen) => listen,
             Err(err) => {
                 return Err(BaguaNetError::TCPError(format!("{:?}", err)));
@@ -685,12 +685,14 @@ impl BaguaNet {
 
     pub fn close_send(&mut self, send_comm_id: SocketSendCommID) -> Result<(), BaguaNetError> {
         self.send_comm_map.remove(&send_comm_id);
+        println!("close_send send_comm_id={}", send_comm_id);
 
         Ok(())
     }
 
     pub fn close_recv(&mut self, recv_comm_id: SocketRecvCommID) -> Result<(), BaguaNetError> {
         self.recv_comm_map.remove(&recv_comm_id);
+        println!("close_recv recv_comm_id={}", recv_comm_id);
 
         Ok(())
     }

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -660,6 +660,7 @@ impl BaguaNet {
                 if task_completed {
                     send_req.trace_span.end();
                 }
+                println!("state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
             SocketRequest::RecvRequest(recv_req) => {
@@ -672,6 +673,7 @@ impl BaguaNet {
                 if task_completed {
                     recv_req.trace_span.end();
                 }
+                println!("state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
         };

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -484,6 +484,7 @@ impl BaguaNet {
                     return Err(BaguaNetError::TCPError(format!("{:?}", err)));
                 }
             };
+            println!("accept addr={:?}", _addr.clone());
             let mut size_bytes = (0 as usize).to_be_bytes();
             stream.read_exact(&mut size_bytes[..]).unwrap();
             // println!("i={}, size_bytes={}", i, usize::from_be_bytes(size_bytes));

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -660,7 +660,7 @@ impl BaguaNet {
                 if task_completed {
                     send_req.trace_span.end();
                 }
-                println!("state={:?}", state);
+                println!("send_req.state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
             SocketRequest::RecvRequest(recv_req) => {
@@ -673,7 +673,7 @@ impl BaguaNet {
                 if task_completed {
                     recv_req.trace_span.end();
                 }
-                println!("state={:?}", state);
+                println!("recv_req.state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
         };

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -350,6 +350,7 @@ impl BaguaNet {
     ) -> Result<SocketSendCommID, BaguaNetError> {
         let mut streams_input = Vec::new();
         for i in 0..self.nstreams {
+            println!("connect {:?}", socket_handle.addr.clone().to_str());
             let mut stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
                 Ok(stream) => stream,
                 Err(err) => {
@@ -485,7 +486,7 @@ impl BaguaNet {
             };
             let mut size_bytes = (0 as usize).to_be_bytes();
             stream.read_exact(&mut size_bytes[..]).unwrap();
-            println!("i={}, size_bytes={}", i, usize::from_be_bytes(size_bytes));
+            // println!("i={}, size_bytes={}", i, usize::from_be_bytes(size_bytes));
 
             let (msg_sender, mut msg_receiver) =
                 mpsc::unbounded_channel::<(&'static mut [u8], Arc<Mutex<RequestState>>)>();

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -350,7 +350,7 @@ impl BaguaNet {
     ) -> Result<SocketSendCommID, BaguaNetError> {
         let mut streams_input = Vec::new();
         for _ in 0..self.nstreams {
-            let mut stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
+            let stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
                 Ok(stream) => stream,
                 Err(err) => {
                     tracing::warn!(
@@ -394,7 +394,7 @@ impl BaguaNet {
             streams_input.push(msg_sender);
         }
 
-        let mut ctrl_stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
+        let ctrl_stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
             Ok(ctrl_stream) => ctrl_stream,
             Err(err) => {
                 tracing::warn!(
@@ -471,7 +471,7 @@ impl BaguaNet {
         let listen_comm = self.listen_comm_map.get(&listen_comm_id).unwrap();
         let mut streams_input = Vec::new();
         for _ in 0..self.nstreams {
-            let (mut stream, _addr) = match listen_comm.tcp_listener.lock().unwrap().accept() {
+            let (stream, _addr) = match listen_comm.tcp_listener.lock().unwrap().accept() {
                 Ok(listen) => listen,
                 Err(err) => {
                     return Err(BaguaNetError::TCPError(format!("{:?}", err)));
@@ -491,7 +491,7 @@ impl BaguaNet {
                     };
 
                     stream.read_exact(&mut data[..]).await.unwrap();
-                    metrics.irecv_nbytes_gauge.record(data.len() as u64);
+                    // metrics.irecv_nbytes_gauge.record(data.len() as u64);
 
                     match state.lock() {
                         Ok(mut state) => {

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -277,7 +277,12 @@ impl BaguaNet {
                 .parse()
                 .unwrap(),
             tokio_rt: tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(8)
+                .worker_threads(
+                    std::env::var("BAGUA_NET_TOKIO_WORKER_THREADS")
+                        .unwrap_or("4".to_owned())
+                        .parse()
+                        .unwrap(),
+                )
                 .enable_all()
                 .build()
                 .unwrap(),

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -412,7 +412,7 @@ impl BaguaNet {
                 )));
             }
         };
-        println!("connect on local_addr={:?}", ctrl_stream.local_addr());
+        println!("{:?} connect to {:?}", ctrl_stream.local_addr(), ctrl_stream.peer_addr());
 
         let (msg_sender, mut msg_receiver) = tokio::sync::mpsc::unbounded_channel();
         let task_split_threshold = self.task_split_threshold;

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -408,6 +408,7 @@ impl BaguaNet {
                 )));
             }
         };
+        println!("connect on local_addr={:?}", ctrl_stream.local_addr());
 
         let (msg_sender, mut msg_receiver) = tokio::sync::mpsc::unbounded_channel();
         let task_split_threshold = self.task_split_threshold;
@@ -511,6 +512,8 @@ impl BaguaNet {
                 return Err(BaguaNetError::TCPError(format!("{:?}", err)));
             }
         };
+
+        println!("listen on local_addr={:?}", ctrl_stream.local_addr());
 
         let (msg_sender, mut msg_receiver) = mpsc::unbounded_channel();
         let task_split_threshold = self.task_split_threshold;

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -365,7 +365,7 @@ impl BaguaNet {
                     )));
                 }
             };
-            println!(
+            tracing::debug!(
                 "{:?} connect to {:?}",
                 stream.local_addr(),
                 socket_handle.addr.clone().to_str()
@@ -435,7 +435,7 @@ impl BaguaNet {
             }
         };
         ctrl_stream.write_all(&self.nstreams.to_be_bytes()[..]).unwrap();
-        println!(
+        tracing::debug!(
             "ctrl_stream {:?} connect to {:?}",
             ctrl_stream.local_addr(),
             ctrl_stream.peer_addr()
@@ -715,7 +715,6 @@ impl BaguaNet {
                 if task_completed {
                     send_req.trace_span.end();
                 }
-                // println!("send_req.state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
             SocketRequest::RecvRequest(recv_req) => {
@@ -728,7 +727,6 @@ impl BaguaNet {
                 if task_completed {
                     recv_req.trace_span.end();
                 }
-                // println!("recv_req.state={:?}", state);
                 Ok((task_completed, state.nbytes_transferred))
             }
         };
@@ -744,14 +742,14 @@ impl BaguaNet {
 
     pub fn close_send(&mut self, send_comm_id: SocketSendCommID) -> Result<(), BaguaNetError> {
         self.send_comm_map.remove(&send_comm_id);
-        println!("close_send send_comm_id={}", send_comm_id);
+        tracing::debug!("close_send send_comm_id={}", send_comm_id);
 
         Ok(())
     }
 
     pub fn close_recv(&mut self, recv_comm_id: SocketRecvCommID) -> Result<(), BaguaNetError> {
         self.recv_comm_map.remove(&recv_comm_id);
-        println!("close_recv recv_comm_id={}", recv_comm_id);
+        tracing::debug!("close_recv recv_comm_id={}", recv_comm_id);
 
         Ok(())
     }

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -370,6 +370,7 @@ impl BaguaNet {
                 stream.local_addr(),
                 socket_handle.addr.clone().to_str()
             );
+            stream.set_nodelay(true).unwrap();
             stream
                 .set_write_timeout(Some(Duration::from_secs_f64(30.)))
                 .unwrap();
@@ -512,6 +513,7 @@ impl BaguaNet {
             };
             println!("{:?} accept addr={:?}", stream.local_addr(), _addr.clone());
             let mut size_bytes = (0 as usize).to_be_bytes();
+            stream.set_nodelay(true).unwrap();
             stream
                 .set_read_timeout(Some(Duration::from_secs_f64(30.)))
                 .unwrap();

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -484,7 +484,7 @@ impl BaguaNet {
                     return Err(BaguaNetError::TCPError(format!("{:?}", err)));
                 }
             };
-            println!("accept addr={:?}", _addr.clone());
+            println!("{:?} accept addr={:?}", stream.local_addr(), _addr.clone());
             let mut size_bytes = (0 as usize).to_be_bytes();
             stream.read_exact(&mut size_bytes[..]).unwrap();
             // println!("i={}, size_bytes={}", i, usize::from_be_bytes(size_bytes));

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -54,7 +54,7 @@ pub struct SocketRecvComm {
     pub msg_sender: mpsc::UnboundedSender<(&'static mut [u8], Arc<Mutex<RequestState>>)>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum BaguaNetError {
     #[error("io error")]
     IOError(String),
@@ -649,7 +649,7 @@ impl BaguaNet {
         let ret = match request {
             SocketRequest::SendRequest(send_req) => {
                 let state = send_req.state.lock().unwrap();
-                if let Some(err) = state.err {
+                if let Some(err) = state.err.clone() {
                     return Err(err);
                 }
 
@@ -661,7 +661,7 @@ impl BaguaNet {
             }
             SocketRequest::RecvRequest(recv_req) => {
                 let state = recv_req.state.lock().unwrap();
-                if let Some(err) = state.err {
+                if let Some(err) = state.err.clone() {
                     return Err(err);
                 }
 

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -370,12 +370,6 @@ impl BaguaNet {
             // let metrics = self.state.clone();
             // TODO: Consider dynamically assigning tasks to make the least stream full
             self.tokio_rt.spawn(async move {
-                println!(
-                    "bagua-net sendstream pid={:?} tid={:?}",
-                    std::process::id(),
-                    std::thread::current().id()
-                );
-
                 let mut stream = tokio::net::TcpStream::from_std(stream).unwrap();
                 stream.set_nodelay(true).unwrap();
                 loop {
@@ -422,11 +416,6 @@ impl BaguaNet {
         let metrics = self.state.clone();
         let send_comm = SocketSendComm { msg_sender: msg_sender };
         self.tokio_rt.spawn(async move {
-            println!(
-                "bagua-net SendComm pid={:?} tid={:?}",
-                std::process::id(),
-                std::thread::current().id()
-            );
             let mut ctrl_stream = tokio::net::TcpStream::from_std(ctrl_stream).unwrap();
             ctrl_stream.set_nodelay(true).unwrap();
             let out_timer = std::time::Instant::now();
@@ -493,11 +482,6 @@ impl BaguaNet {
                 mpsc::unbounded_channel::<(&'static mut [u8], Arc<Mutex<RequestState>>)>();
             let metrics = self.state.clone();
             self.tokio_rt.spawn(async move {
-                println!(
-                    "bagua-net recvstream pid={:?} tid={:?}",
-                    std::process::id(),
-                    std::thread::current().id()
-                );
                 let mut stream = tokio::net::TcpStream::from_std(stream).unwrap();
                 stream.set_nodelay(true).unwrap();
                 loop {
@@ -538,11 +522,6 @@ impl BaguaNet {
             msg_sender: msg_sender,
         };
         self.tokio_rt.spawn(async move {
-            println!(
-                "bagua-net SocketRecvComm pid={:?} tid={:?}",
-                std::process::id(),
-                std::thread::current().id()
-            );
             let mut ctrl_stream = tokio::net::TcpStream::from_std(ctrl_stream).unwrap();
             ctrl_stream.set_nodelay(true).unwrap();
             let mut downstream_id = 0;

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -508,7 +508,7 @@ impl BaguaNet {
 
         let mut ctrl_stream = None;
         let mut oredered_streams = std::collections::BTreeMap::new();
-        for _ in 0..self.nstreams + 1 {
+        for _ in 0..=self.nstreams {
             let (mut stream, _addr) = match listen_comm.tcp_listener.lock().unwrap().accept() {
                 Ok(listen) => listen,
                 Err(err) => {

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -276,7 +276,11 @@ impl BaguaNet {
                 .unwrap_or("65536".to_owned())
                 .parse()
                 .unwrap(),
-            tokio_rt: tokio::runtime::Runtime::new().unwrap(),
+            tokio_rt: tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .enable_all()
+                .build()
+                .unwrap(),
         })
     }
 
@@ -400,13 +404,10 @@ impl BaguaNet {
                     continue;
                 }
 
-                let mut chunks = data.chunks(utils::chunk_size(
-                    data.len(),
-                    min_chunksize,
-                    nstreams,
-                ));
+                let mut chunks =
+                    data.chunks(utils::chunk_size(data.len(), min_chunksize, nstreams));
 
-                let mut datapass_fut = Vec::new();
+                let mut datapass_fut = Vec::with_capacity(stream_vec.len());
                 for stream in stream_vec.iter_mut() {
                     let chunk = match chunks.next() {
                         Some(b) => b,
@@ -540,12 +541,9 @@ impl BaguaNet {
                     continue;
                 }
 
-                let mut chunks = data.chunks_mut(utils::chunk_size(
-                    data.len(),
-                    min_chunksize,
-                    nstreams,
-                ));
-                let mut datapass_fut = Vec::new();
+                let mut chunks =
+                    data.chunks_mut(utils::chunk_size(data.len(), min_chunksize, nstreams));
+                let mut datapass_fut = Vec::with_capacity(stream_vec.len());
                 for stream in stream_vec.iter_mut() {
                     let chunk = match chunks.next() {
                         Some(b) => b,

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -549,6 +549,7 @@ impl BaguaNet {
                                 target_nbytes,
                                 data.len(),
                             )));
+                            break;
                         }
                         Err(poisoned) => {
                             tracing::warn!("{:?}", poisoned);

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -464,7 +464,7 @@ impl BaguaNet {
                 // let send_nbytes = data.len().to_be_bytes();
                 // ctrl_stream.write_all(&send_nbytes[..]).await.unwrap();
                 ctrl_stream.write_u32(data.len() as u32).await.unwrap();
-                tracing::debug!(
+                println!(
                     "send to {:?} target_nbytes={}",
                     ctrl_stream.peer_addr(),
                     data.len()
@@ -584,7 +584,7 @@ impl BaguaNet {
                     }
                 };
 
-                tracing::debug!(
+                println!(
                     "{:?} recv target_nbytes={}",
                     ctrl_stream.local_addr(),
                     target_nbytes

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -464,11 +464,11 @@ impl BaguaNet {
                 // let send_nbytes = data.len().to_be_bytes();
                 // ctrl_stream.write_all(&send_nbytes[..]).await.unwrap();
                 ctrl_stream.write_u32(data.len() as u32).await.unwrap();
-                println!(
-                    "send to {:?} target_nbytes={}",
-                    ctrl_stream.peer_addr(),
-                    data.len()
-                );
+                // println!(
+                //     "send to {:?} target_nbytes={}",
+                //     ctrl_stream.peer_addr(),
+                //     data.len()
+                // );
 
                 if data.len() != 0 {
                     let bucket_size =
@@ -583,19 +583,12 @@ impl BaguaNet {
                         return;
                     }
                 };
-                // let mut target_nbytes = data.len().to_be_bytes();
-                // if let Err(err) = ctrl_stream.read_exact(&mut target_nbytes[..]).await {
-                //     state.lock().unwrap().err =
-                //         Some(BaguaNetError::InnerError(format!("{:?}", err)));
-                //     break;
-                // }
-                // let target_nbytes = usize::from_be_bytes(target_nbytes);
 
-                println!(
-                    "{:?} recv target_nbytes={}",
-                    ctrl_stream.local_addr(),
-                    target_nbytes
-                );
+                // println!(
+                //     "{:?} recv target_nbytes={}",
+                //     ctrl_stream.local_addr(),
+                //     target_nbytes
+                // );
 
                 if target_nbytes == 0 {
                     state.lock().unwrap().completed_subtasks += 1;

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -434,8 +434,9 @@ impl BaguaNet {
                     None => break,
                 };
                 let in_timer = std::time::Instant::now();
-                let send_nbytes = data.len().to_be_bytes();
-                ctrl_stream.write_all(&send_nbytes[..]).await.unwrap();
+                // let send_nbytes = data.len().to_be_bytes();
+                // ctrl_stream.write_all(&send_nbytes[..]).await.unwrap();
+                ctrl_stream.write_u32(data.len() as u32).await.unwrap();
                 println!("send to {:?} target_nbytes={}", ctrl_stream.peer_addr(), data.len());
 
                 if data.len() != 0 {
@@ -536,13 +537,21 @@ impl BaguaNet {
                     Some(it) => it,
                     None => break,
                 };
-                let mut target_nbytes = data.len().to_be_bytes();
-                if let Err(err) = ctrl_stream.read_exact(&mut target_nbytes[..]).await {
-                    state.lock().unwrap().err =
+                let target_nbytes = match ctrl_stream.read_u32().await {
+                    Ok(nbytes) => nbytes as usize,
+                    Err(err) => {
+                        state.lock().unwrap().err =
                         Some(BaguaNetError::InnerError(format!("{:?}", err)));
-                    break;
-                }
-                let target_nbytes = usize::from_be_bytes(target_nbytes);
+                        return;
+                    }
+                };
+                // let mut target_nbytes = data.len().to_be_bytes();
+                // if let Err(err) = ctrl_stream.read_exact(&mut target_nbytes[..]).await {
+                //     state.lock().unwrap().err =
+                //         Some(BaguaNetError::InnerError(format!("{:?}", err)));
+                //     break;
+                // }
+                // let target_nbytes = usize::from_be_bytes(target_nbytes);
 
                 println!("{:?} recv target_nbytes={}", ctrl_stream.local_addr(), target_nbytes);
 

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -520,7 +520,7 @@ impl BaguaNet {
             stream.read_exact(&mut stream_id[..]).unwrap();
             let stream_id = usize::from_be_bytes(stream_id);
 
-            println!("stream_id={}", stream_id);
+            println!("self.nstreams={}, stream_id={}", self.nstreams, stream_id);
 
             if stream_id == self.nstreams {
                 ctrl_stream = Some(stream);

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -448,12 +448,12 @@ impl BaguaNet {
                 }
                 state.lock().unwrap().completed_subtasks += 1;
 
-                let dur = in_timer.elapsed().as_secs_f64();
-                sum_in_time += dur;
+                // let dur = in_timer.elapsed().as_secs_f64();
+                // sum_in_time += dur;
 
-                *metrics.isend_per_second.lock().unwrap() = 1. / dur;
-                *metrics.isend_percentage_of_effective_time.lock().unwrap() =
-                    sum_in_time / out_timer.elapsed().as_secs_f64();
+                // *metrics.isend_per_second.lock().unwrap() = 1. / dur;
+                // *metrics.isend_percentage_of_effective_time.lock().unwrap() =
+                //     sum_in_time / out_timer.elapsed().as_secs_f64();
             }
         });
         self.send_comm_map.insert(

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -350,7 +350,6 @@ impl BaguaNet {
     ) -> Result<SocketSendCommID, BaguaNetError> {
         let mut streams_input = Vec::new();
         for i in 0..self.nstreams {
-            println!("connect {:?}", socket_handle.addr.clone().to_str());
             let mut stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
                 Ok(stream) => stream,
                 Err(err) => {
@@ -365,6 +364,7 @@ impl BaguaNet {
                     )));
                 }
             };
+            println!("{:?} connect to {:?}", stream.local_addr(), socket_handle.addr.clone().to_str());
             stream.write_all(&i.to_be_bytes()[..]).unwrap();
 
             let (msg_sender, mut msg_receiver) =
@@ -414,7 +414,7 @@ impl BaguaNet {
                 )));
             }
         };
-        println!("{:?} connect to {:?}", ctrl_stream.local_addr(), ctrl_stream.peer_addr());
+        println!("ctrl_stream {:?} connect to {:?}", ctrl_stream.local_addr(), ctrl_stream.peer_addr());
 
         let (msg_sender, mut msg_receiver) = tokio::sync::mpsc::unbounded_channel();
         let task_split_threshold = self.task_split_threshold;

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -464,11 +464,11 @@ impl BaguaNet {
                 // let send_nbytes = data.len().to_be_bytes();
                 // ctrl_stream.write_all(&send_nbytes[..]).await.unwrap();
                 ctrl_stream.write_u32(data.len() as u32).await.unwrap();
-                // println!(
-                //     "send to {:?} target_nbytes={}",
-                //     ctrl_stream.peer_addr(),
-                //     data.len()
-                // );
+                tracing::debug!(
+                    "send to {:?} target_nbytes={}",
+                    ctrl_stream.peer_addr(),
+                    data.len()
+                );
 
                 if data.len() != 0 {
                     let bucket_size =
@@ -584,11 +584,11 @@ impl BaguaNet {
                     }
                 };
 
-                // println!(
-                //     "{:?} recv target_nbytes={}",
-                //     ctrl_stream.local_addr(),
-                //     target_nbytes
-                // );
+                tracing::debug!(
+                    "{:?} recv target_nbytes={}",
+                    ctrl_stream.local_addr(),
+                    target_nbytes
+                );
 
                 if target_nbytes == 0 {
                     state.lock().unwrap().completed_subtasks += 1;

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -520,12 +520,10 @@ impl BaguaNet {
             stream.read_exact(&mut stream_id[..]).unwrap();
             let stream_id = usize::from_be_bytes(stream_id);
 
-            println!("self.nstreams={}, stream_id={}", self.nstreams, stream_id);
-
             if stream_id == self.nstreams {
                 ctrl_stream = Some(stream);
             } else {
-                oredered_streams.insert(stream_id, stream).unwrap();
+                oredered_streams.insert(stream_id, stream);
             }
         }
         let ctrl_stream = ctrl_stream.unwrap();

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -428,7 +428,6 @@ impl BaguaNet {
                 std::process::id(),
                 std::thread::current().id()
             );
-            println!("write_all raw peer={}", ctrl_stream.peer_addr().unwrap());
             let mut ctrl_stream = tokio::net::TcpStream::from_std(ctrl_stream).unwrap();
             let out_timer = std::time::Instant::now();
             let mut sum_in_time = 0.;
@@ -440,9 +439,7 @@ impl BaguaNet {
                 };
                 let in_timer = std::time::Instant::now();
                 let send_nbytes = data.len().to_be_bytes();
-                println!("go write target_nbytes");
                 ctrl_stream.write_all(&send_nbytes[..]).await.unwrap();
-                println!("write_all target_nbytes={}, peer={:?}", data.len(), ctrl_stream.peer_addr().unwrap());
 
                 if data.len() != 0 {
                     let bucket_size = if data.len() >= task_split_threshold
@@ -548,7 +545,6 @@ impl BaguaNet {
                 std::process::id(),
                 std::thread::current().id()
             );
-            println!("read_exact raw local={}", ctrl_stream.local_addr().unwrap());
             let mut ctrl_stream = tokio::net::TcpStream::from_std(ctrl_stream).unwrap();
             let mut downstream_id = 0;
             loop {
@@ -557,13 +553,11 @@ impl BaguaNet {
                     None => break,
                 };
                 let mut target_nbytes = data.len().to_be_bytes();
-                println!("ready to read_exact, addr={:?}", ctrl_stream.local_addr().unwrap());
                 ctrl_stream
                     .read_exact(&mut target_nbytes[..])
                     .await
                     .unwrap();
                 let target_nbytes = usize::from_be_bytes(target_nbytes);
-                println!("target_nbytes={}", target_nbytes);
 
                 if target_nbytes == 0 {
                     state.lock().unwrap().completed_subtasks += 1;

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -464,7 +464,7 @@ impl BaguaNet {
                 // let send_nbytes = data.len().to_be_bytes();
                 // ctrl_stream.write_all(&send_nbytes[..]).await.unwrap();
                 ctrl_stream.write_u32(data.len() as u32).await.unwrap();
-                println!(
+                tracing::debug!(
                     "send to {:?} target_nbytes={}",
                     ctrl_stream.peer_addr(),
                     data.len()
@@ -584,7 +584,7 @@ impl BaguaNet {
                     }
                 };
 
-                println!(
+                tracing::debug!(
                     "{:?} recv target_nbytes={}",
                     ctrl_stream.local_addr(),
                     target_nbytes

--- a/src/bagua_net.rs
+++ b/src/bagua_net.rs
@@ -544,8 +544,11 @@ impl BaguaNet {
                 } else if target_nbytes > data.len() {
                     match state.lock() {
                         Ok(mut state) => {
-                            state.completed_subtasks += 1;
-                            state.nbytes_transferred += data.len();
+                            state.err = Some(BaguaNetError::InnerError(format!(
+                                "Invalid target_nbytes!! target_nbytes={}, buff.len={}",
+                                target_nbytes,
+                                data.len(),
+                            )));
                         }
                         Err(poisoned) => {
                             tracing::warn!("{:?}", poisoned);

--- a/src/implement/mod.rs
+++ b/src/implement/mod.rs
@@ -1,0 +1,1 @@
+pub mod tokio_backend;

--- a/src/implement/mod.rs
+++ b/src/implement/mod.rs
@@ -1,1 +1,2 @@
 pub mod tokio_backend;
+pub mod nthread_per_socket_backend;

--- a/src/implement/nthread_per_socket_backend.rs
+++ b/src/implement/nthread_per_socket_backend.rs
@@ -229,7 +229,7 @@ impl BaguaNet {
                 .parse()
                 .unwrap(),
             min_chunksize: std::env::var("BAGUA_NET_MIN_CHUNKSIZE")
-                .unwrap_or("65536".to_owned())
+                .unwrap_or("1048576".to_owned())
                 .parse()
                 .unwrap(),
         })

--- a/src/implement/nthread_per_socket_backend.rs
+++ b/src/implement/nthread_per_socket_backend.rs
@@ -1,0 +1,636 @@
+use crate::interface;
+use crate::interface::{
+    BaguaNetError, NCCLNetProperties, Net, SocketHandle, SocketListenCommID, SocketRecvCommID,
+    SocketRequestID, SocketSendCommID,
+};
+use crate::utils;
+use crate::utils::NCCLSocketDev;
+use nix::sys::socket::{InetAddr, SockAddr};
+use opentelemetry::{
+    metrics::{BoundValueRecorder, ObserverResult},
+    trace::{Span, TraceContextExt, Tracer},
+    KeyValue,
+};
+use socket2::{Domain, Socket, Type};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net;
+use std::sync::{Arc, Mutex};
+
+const NCCL_PTR_HOST: i32 = 1;
+const NCCL_PTR_CUDA: i32 = 2;
+
+lazy_static! {
+    static ref HANDLER_ALL: [KeyValue; 1] = [KeyValue::new("handler", "all")];
+}
+
+pub struct SocketListenComm {
+    pub tcp_listener: Arc<Mutex<net::TcpListener>>,
+}
+
+// TODO: make Rotating communicator
+#[derive(Clone)]
+pub struct SocketSendComm {
+    pub tcp_sender: Arc<std::thread::JoinHandle<()>>,
+    pub msg_sender: flume::Sender<(&'static [u8], Arc<Mutex<RequestState>>)>,
+}
+
+#[derive(Clone)]
+pub struct SocketRecvComm {
+    pub tcp_sender: Arc<std::thread::JoinHandle<()>>,
+    pub msg_sender: flume::Sender<(&'static mut [u8], Arc<Mutex<RequestState>>)>,
+}
+
+pub struct SocketSendRequest {
+    pub state: Arc<Mutex<RequestState>>,
+    pub trace_span: opentelemetry::global::BoxedSpan,
+}
+
+pub struct SocketRecvRequest {
+    pub state: Arc<Mutex<RequestState>>,
+    pub trace_span: opentelemetry::global::BoxedSpan,
+}
+
+#[derive(Debug)]
+pub struct RequestState {
+    pub nsubtasks: usize,
+    pub completed_subtasks: usize,
+    pub nbytes_transferred: usize,
+}
+
+pub enum SocketRequest {
+    SendRequest(SocketSendRequest),
+    RecvRequest(SocketRecvRequest),
+}
+
+static TELEMETRY_INIT_ONCE: std::sync::Once = std::sync::Once::new();
+// static TELEMETRY_GUARD: Option<TelemetryGuard> = None;
+
+struct AppState {
+    exporter: opentelemetry_prometheus::PrometheusExporter,
+    isend_nbytes_gauge: BoundValueRecorder<'static, u64>,
+    irecv_nbytes_gauge: BoundValueRecorder<'static, u64>,
+    isend_nbytes_per_second: Arc<Mutex<f64>>,
+    isend_percentage_of_effective_time: Arc<Mutex<f64>>,
+    // isend_nbytes_gauge: BoundValueRecorder<'static, u64>,
+    // irecv_nbytes_gauge: BoundValueRecorder<'static, u64>,
+    uploader: std::thread::JoinHandle<()>,
+}
+
+pub struct BaguaNet {
+    pub socket_devs: Vec<NCCLSocketDev>,
+    pub listen_comm_next_id: usize,
+    pub listen_comm_map: HashMap<SocketListenCommID, SocketListenComm>,
+    pub send_comm_next_id: usize,
+    pub send_comm_map: HashMap<SocketSendCommID, SocketSendComm>,
+    pub recv_comm_next_id: usize,
+    pub recv_comm_map: HashMap<SocketRecvCommID, SocketRecvComm>,
+    pub socket_request_next_id: usize,
+    pub socket_request_map: HashMap<SocketRequestID, SocketRequest>,
+    pub trace_span_context: opentelemetry::Context,
+    pub trace_on_flag: bool,
+    pub rank: i32,
+    state: Arc<AppState>,
+    nstreams: usize,
+    task_split_threshold: usize,
+}
+
+impl BaguaNet {
+    const DEFAULT_SOCKET_MAX_COMMS: i32 = 65536;
+    const DEFAULT_LISTEN_BACKLOG: i32 = 16384;
+
+    pub fn new() -> Result<BaguaNet, BaguaNetError> {
+        let rank: i32 = std::env::var("RANK")
+            .unwrap_or("-1".to_string())
+            .parse()
+            .unwrap();
+        TELEMETRY_INIT_ONCE.call_once(|| {
+            if rank == -1 || rank > 7 {
+                return;
+            }
+
+            let jaeger_addr = match std::env::var("BAGUA_NET_JAEGER_ADDRESS") {
+                Ok(jaeger_addr) => {
+                    tracing::info!("detected auto tuning server, connecting");
+                    jaeger_addr
+                }
+                Err(_) => {
+                    tracing::warn!("Jaeger server not detected.");
+                    return;
+                }
+            };
+
+            opentelemetry::global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
+            opentelemetry_jaeger::new_pipeline()
+                .with_collector_endpoint(format!("http://{}/api/traces", jaeger_addr))
+                .with_service_name("bagua-net")
+                .install_batch(opentelemetry::runtime::AsyncStd)
+                .unwrap();
+        });
+
+        let tracer = opentelemetry::global::tracer("bagua-net");
+        let mut span = tracer.start(format!("BaguaNet-{}", rank));
+        span.set_attribute(KeyValue::new(
+            "socket_devs",
+            format!("{:?}", utils::find_interfaces()),
+        ));
+
+        let prom_exporter = opentelemetry_prometheus::exporter()
+            .with_default_histogram_boundaries(vec![16., 1024., 4096., 1048576.])
+            .init();
+
+        let isend_nbytes_per_second = Arc::new(Mutex::new(0.));
+        let isend_percentage_of_effective_time = Arc::new(Mutex::new(0.));
+
+        let meter = opentelemetry::global::meter("bagua-net");
+        let isend_nbytes_per_second_clone = isend_nbytes_per_second.clone();
+        meter
+            .f64_value_observer(
+                "isend_nbytes_per_second",
+                move |res: ObserverResult<f64>| {
+                    res.observe(
+                        *isend_nbytes_per_second_clone.lock().unwrap(),
+                        HANDLER_ALL.as_ref(),
+                    );
+                },
+            )
+            .init();
+        let isend_percentage_of_effective_time_clone = isend_percentage_of_effective_time.clone();
+        meter
+            .f64_value_observer(
+                "isend_percentage_of_effective_time",
+                move |res: ObserverResult<f64>| {
+                    res.observe(
+                        *isend_percentage_of_effective_time_clone.lock().unwrap(),
+                        HANDLER_ALL.as_ref(),
+                    );
+                },
+            )
+            .init();
+        let state = Arc::new(AppState {
+            exporter: prom_exporter.clone(),
+            isend_nbytes_gauge: meter
+                .u64_value_recorder("isend_nbytes")
+                .init()
+                .bind(HANDLER_ALL.as_ref()),
+            irecv_nbytes_gauge: meter
+                .u64_value_recorder("irecv_nbytes")
+                .init()
+                .bind(HANDLER_ALL.as_ref()),
+            isend_nbytes_per_second: isend_nbytes_per_second,
+            isend_percentage_of_effective_time: isend_percentage_of_effective_time,
+            uploader: std::thread::spawn(move || {
+                let prometheus_addr =
+                    std::env::var("BAGUA_NET_PROMETHEUS_ADDRESS").unwrap_or_default();
+                let (user, pass, address) = match utils::parse_user_pass_and_addr(&prometheus_addr)
+                {
+                    Some(ret) => ret,
+                    None => return,
+                };
+
+                loop {
+                    std::thread::sleep(std::time::Duration::from_micros(200));
+                    let metric_families = prom_exporter.registry().gather();
+                    match prometheus::push_metrics(
+                        "BaguaNet",
+                        prometheus::labels! { "rank".to_owned() => rank.to_string(), },
+                        &address,
+                        metric_families,
+                        Some(prometheus::BasicAuthentication {
+                            username: user.clone(),
+                            password: pass.clone(),
+                        }),
+                    ) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            tracing::warn!("{:?}", err);
+                        }
+                    }
+                }
+            }),
+        });
+
+        Ok(Self {
+            socket_devs: utils::find_interfaces(),
+            listen_comm_next_id: 0,
+            listen_comm_map: Default::default(),
+            send_comm_next_id: 0,
+            send_comm_map: Default::default(),
+            recv_comm_next_id: 0,
+            recv_comm_map: Default::default(),
+            socket_request_next_id: 0,
+            socket_request_map: Default::default(),
+            trace_span_context: opentelemetry::Context::current_with_span(span),
+            rank: rank,
+            trace_on_flag: rank < 8,
+            state: state,
+            nstreams: std::env::var("BAGUA_NET_NSTREAMS")
+                .unwrap_or("2".to_owned())
+                .parse()
+                .unwrap(),
+            task_split_threshold: std::env::var("BAGUA_NET_TASK_SPLIT_THRESHOLD")
+                .unwrap_or("1048576".to_owned())
+                .parse()
+                .unwrap(),
+        })
+    }
+}
+
+impl Net for BaguaNet {
+    fn devices(&self) -> Result<usize, BaguaNetError> {
+        Ok(self.socket_devs.len())
+    }
+
+    fn get_properties(&self, dev_id: usize) -> Result<NCCLNetProperties, BaguaNetError> {
+        let socket_dev = &self.socket_devs[dev_id];
+
+        Ok(NCCLNetProperties {
+            name: socket_dev.interface_name.clone(),
+            pci_path: socket_dev.pci_path.clone(),
+            guid: dev_id as u64,
+            ptr_support: NCCL_PTR_HOST,
+            speed: utils::get_net_if_speed(&socket_dev.interface_name),
+            port: 0,
+            max_comms: BaguaNet::DEFAULT_SOCKET_MAX_COMMS,
+        })
+    }
+
+    fn listen(
+        &mut self,
+        dev_id: usize,
+    ) -> Result<(SocketHandle, SocketListenCommID), BaguaNetError> {
+        let socket_dev = &self.socket_devs[dev_id];
+        let addr = match socket_dev.addr.clone() {
+            SockAddr::Inet(inet_addr) => inet_addr,
+            others => {
+                return Err(BaguaNetError::InnerError(format!(
+                    "Got invalid socket address, which is {:?}",
+                    others
+                )))
+            }
+        };
+
+        let socket = match Socket::new(
+            match addr {
+                InetAddr::V4(_) => Domain::IPV4,
+                InetAddr::V6(_) => Domain::IPV6,
+            },
+            Type::STREAM,
+            None,
+        ) {
+            Ok(sock) => sock,
+            Err(err) => return Err(BaguaNetError::IOError(format!("{:?}", err))),
+        };
+        socket.bind(&addr.to_std().into()).unwrap();
+        socket.listen(BaguaNet::DEFAULT_LISTEN_BACKLOG).unwrap();
+
+        let listener: net::TcpListener = socket.into();
+        let socket_addr = listener.local_addr().unwrap();
+        let socket_handle = SocketHandle {
+            addr: SockAddr::new_inet(InetAddr::from_std(&socket_addr)),
+        };
+        let id = self.listen_comm_next_id;
+        self.listen_comm_next_id += 1;
+        self.listen_comm_map.insert(
+            id,
+            SocketListenComm {
+                tcp_listener: Arc::new(Mutex::new(listener)),
+            },
+        );
+
+        Ok((socket_handle, id))
+    }
+
+    fn connect(
+        &mut self,
+        _dev_id: usize,
+        socket_handle: SocketHandle,
+    ) -> Result<SocketSendCommID, BaguaNetError> {
+        let mut parallel_streams = Vec::new();
+        let mut streams_input = Vec::new();
+        for _ in 0..self.nstreams {
+            let mut stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
+                Ok(stream) => stream,
+                Err(err) => {
+                    tracing::warn!(
+                        "net::TcpStream::connect failed, err={:?}, socket_handle={:?}",
+                        err,
+                        socket_handle
+                    );
+                    return Err(BaguaNetError::TCPError(format!(
+                        "socket_handle={:?}, err={:?}",
+                        socket_handle, err
+                    )));
+                }
+            };
+            stream.set_nodelay(true).unwrap();
+            stream.set_nonblocking(true).unwrap();
+
+            let (msg_sender, msg_receiver) =
+                flume::unbounded::<(&'static [u8], Arc<Mutex<RequestState>>)>();
+            let metrics = self.state.clone();
+            // TODO: Consider dynamically assigning tasks to make the least stream full
+            parallel_streams.push(std::thread::spawn(move || {
+                let out_timer = std::time::Instant::now();
+                let mut sum_in_time = 0.;
+                for (data, state) in msg_receiver.iter() {
+                    let in_timer = std::time::Instant::now();
+                    utils::nonblocking_write_all(&mut stream, &data[..]).unwrap();
+
+                    let dur = in_timer.elapsed().as_secs_f64();
+                    sum_in_time += dur;
+
+                    *metrics.isend_nbytes_per_second.lock().unwrap() = data.len() as f64 / dur;
+                    *metrics.isend_percentage_of_effective_time.lock().unwrap() =
+                        sum_in_time / out_timer.elapsed().as_secs_f64();
+
+                    metrics.isend_nbytes_gauge.record(data.len() as u64);
+                    match state.lock() {
+                        Ok(mut state) => {
+                            state.completed_subtasks += 1;
+                            state.nbytes_transferred += data.len();
+                        }
+                        Err(poisoned) => {
+                            tracing::warn!("{:?}", poisoned);
+                        }
+                    };
+                }
+            }));
+            streams_input.push(msg_sender);
+        }
+
+        let mut master_stream = match net::TcpStream::connect(socket_handle.addr.clone().to_str()) {
+            Ok(master_stream) => master_stream,
+            Err(err) => {
+                tracing::warn!(
+                    "net::TcpStream::connect failed, err={:?}, socket_handle={:?}",
+                    err,
+                    socket_handle
+                );
+                return Err(BaguaNetError::TCPError(format!(
+                    "socket_handle={:?}, err={:?}",
+                    socket_handle, err
+                )));
+            }
+        };
+        master_stream.set_nodelay(true).unwrap();
+        master_stream.set_nonblocking(true).unwrap();
+
+        let (msg_sender, msg_receiver) = flume::unbounded();
+        let task_split_threshold = self.task_split_threshold;
+        let id = self.send_comm_next_id;
+        self.send_comm_next_id += 1;
+        self.send_comm_map.insert(
+            id,
+            SocketSendComm {
+                msg_sender: msg_sender,
+                tcp_sender: Arc::new(std::thread::spawn(move || {
+                    let mut downstream_id = 0;
+                    for (data, state) in msg_receiver.iter() {
+                        let send_nbytes = data.len().to_be_bytes();
+                        utils::nonblocking_write_all(&mut master_stream, &send_nbytes[..]).unwrap();
+
+                        if data.len() != 0 {
+                            let bucket_size = if data.len() >= task_split_threshold
+                                && data.len() > parallel_streams.len()
+                            {
+                                data.len() + (parallel_streams.len() - 1) / parallel_streams.len()
+                            } else {
+                                data.len()
+                            };
+                            for bucket in data.chunks(bucket_size) {
+                                state.lock().unwrap().nsubtasks += 1;
+                                streams_input[downstream_id]
+                                    .send((bucket, state.clone()))
+                                    .unwrap();
+                                downstream_id = (downstream_id + 1) % parallel_streams.len();
+                            }
+                        }
+
+                        state.lock().unwrap().completed_subtasks += 1;
+                    }
+                })),
+            },
+        );
+
+        Ok(id)
+    }
+
+    fn accept(
+        &mut self,
+        listen_comm_id: SocketListenCommID,
+    ) -> Result<SocketRecvCommID, BaguaNetError> {
+        let listen_comm = self.listen_comm_map.get(&listen_comm_id).unwrap();
+        let mut parallel_streams = Vec::new();
+        let mut streams_input = Vec::new();
+        for _ in 0..self.nstreams {
+            let (mut stream, _addr) = match listen_comm.tcp_listener.lock().unwrap().accept() {
+                Ok(listen) => listen,
+                Err(err) => {
+                    return Err(BaguaNetError::TCPError(format!("{:?}", err)));
+                }
+            };
+            stream.set_nodelay(true).unwrap();
+            stream.set_nonblocking(true).unwrap();
+
+            let (msg_sender, msg_receiver) =
+                flume::unbounded::<(&'static mut [u8], Arc<Mutex<RequestState>>)>();
+            let metrics = self.state.clone();
+            parallel_streams.push(std::thread::spawn(move || {
+                for (data, state) in msg_receiver.iter() {
+                    utils::nonblocking_read_exact(&mut stream, &mut data[..]).unwrap();
+
+                    metrics.irecv_nbytes_gauge.record(data.len() as u64);
+                    match state.lock() {
+                        Ok(mut state) => {
+                            state.completed_subtasks += 1;
+                            state.nbytes_transferred += data.len();
+                        }
+                        Err(poisoned) => {
+                            tracing::warn!("{:?}", poisoned);
+                        }
+                    };
+                }
+            }));
+            streams_input.push(msg_sender);
+        }
+
+        let (mut master_stream, _addr) = match listen_comm.tcp_listener.lock().unwrap().accept() {
+            Ok(listen) => listen,
+            Err(err) => {
+                return Err(BaguaNetError::TCPError(format!("{:?}", err)));
+            }
+        };
+        master_stream.set_nodelay(true).unwrap();
+        master_stream.set_nonblocking(true).unwrap();
+
+        let (msg_sender, msg_receiver) = flume::unbounded();
+        let task_split_threshold = self.task_split_threshold;
+        let id = self.recv_comm_next_id;
+        self.recv_comm_next_id += 1;
+        self.recv_comm_map.insert(
+            id,
+            SocketRecvComm {
+                msg_sender: msg_sender,
+                tcp_sender: Arc::new(std::thread::spawn(move || {
+                    let mut downstream_id = 0;
+                    for (data, state) in msg_receiver.iter() {
+                        let mut target_nbytes = data.len().to_be_bytes();
+                        utils::nonblocking_read_exact(&mut master_stream, &mut target_nbytes[..])
+                            .unwrap();
+                        let target_nbytes = usize::from_be_bytes(target_nbytes);
+
+                        if target_nbytes != 0 {
+                            let bucket_size = if target_nbytes >= task_split_threshold
+                                && target_nbytes > parallel_streams.len()
+                            {
+                                target_nbytes
+                                    + (parallel_streams.len() - 1) / parallel_streams.len()
+                            } else {
+                                target_nbytes
+                            };
+
+                            for bucket in data[..target_nbytes].chunks_mut(bucket_size) {
+                                state.lock().unwrap().nsubtasks += 1;
+                                streams_input[downstream_id]
+                                    .send((&mut bucket[..], state.clone()))
+                                    .unwrap();
+                                downstream_id = (downstream_id + 1) % parallel_streams.len();
+                            }
+                        }
+                        state.lock().unwrap().completed_subtasks += 1;
+                    }
+                })),
+            },
+        );
+
+        Ok(id)
+    }
+
+    fn isend(
+        &mut self,
+        send_comm_id: SocketSendCommID,
+        data: &'static [u8],
+    ) -> Result<SocketRequestID, BaguaNetError> {
+        let tracer = opentelemetry::global::tracer("bagua-net");
+        let mut span = tracer
+            .span_builder(format!("isend-{}", send_comm_id))
+            .with_parent_context(self.trace_span_context.clone())
+            .start(&tracer);
+        let send_comm = self.send_comm_map.get(&send_comm_id).unwrap();
+        let id = self.socket_request_next_id;
+
+        span.set_attribute(KeyValue::new("id", id as i64));
+        span.set_attribute(KeyValue::new("nbytes", data.len() as i64));
+
+        self.socket_request_next_id += 1;
+        let task_state = Arc::new(Mutex::new(RequestState {
+            nsubtasks: 1,
+            completed_subtasks: 0,
+            nbytes_transferred: 0,
+        }));
+        self.socket_request_map.insert(
+            id,
+            SocketRequest::SendRequest(SocketSendRequest {
+                state: task_state.clone(),
+                trace_span: span,
+            }),
+        );
+
+        send_comm.msg_sender.send((data, task_state)).unwrap();
+
+        Ok(id)
+    }
+
+    fn irecv(
+        &mut self,
+        recv_comm_id: SocketRecvCommID,
+        data: &'static mut [u8],
+    ) -> Result<SocketRequestID, BaguaNetError> {
+        let tracer = opentelemetry::global::tracer("bagua-net");
+        let mut span = tracer
+            .span_builder(format!("irecv-{}", recv_comm_id))
+            .with_parent_context(self.trace_span_context.clone())
+            .start(&tracer);
+        let recv_comm = self.recv_comm_map.get(&recv_comm_id).unwrap();
+        let id = self.socket_request_next_id;
+
+        span.set_attribute(KeyValue::new("id", id as i64));
+
+        self.socket_request_next_id += 1;
+        let task_state = Arc::new(Mutex::new(RequestState {
+            nsubtasks: 1,
+            completed_subtasks: 0,
+            nbytes_transferred: 0,
+        }));
+        self.socket_request_map.insert(
+            id,
+            SocketRequest::RecvRequest(SocketRecvRequest {
+                state: task_state.clone(),
+                trace_span: span,
+            }),
+        );
+
+        recv_comm.msg_sender.send((data, task_state)).unwrap();
+
+        Ok(id)
+    }
+
+    fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
+        let request = self.socket_request_map.get_mut(&request_id).unwrap();
+        let ret = match request {
+            SocketRequest::SendRequest(send_req) => {
+                let state = send_req.state.lock().unwrap();
+                let task_completed = state.nsubtasks == state.completed_subtasks;
+
+                if task_completed {
+                    send_req.trace_span.end();
+                }
+                Ok((task_completed, state.nbytes_transferred))
+            }
+            SocketRequest::RecvRequest(recv_req) => {
+                let state = recv_req.state.lock().unwrap();
+                let task_completed = state.nsubtasks == state.completed_subtasks;
+
+                if task_completed {
+                    recv_req.trace_span.end();
+                }
+                Ok((task_completed, state.nbytes_transferred))
+            }
+        };
+
+        if let Ok(ret) = ret {
+            if ret.0 {
+                self.socket_request_map.remove(&request_id).unwrap();
+            }
+        }
+
+        ret
+    }
+
+    fn close_send(&mut self, send_comm_id: SocketSendCommID) -> Result<(), BaguaNetError> {
+        self.send_comm_map.remove(&send_comm_id);
+
+        Ok(())
+    }
+
+    fn close_recv(&mut self, recv_comm_id: SocketRecvCommID) -> Result<(), BaguaNetError> {
+        self.recv_comm_map.remove(&recv_comm_id);
+
+        Ok(())
+    }
+
+    fn close_listen(&mut self, listen_comm_id: SocketListenCommID) -> Result<(), BaguaNetError> {
+        self.listen_comm_map.remove(&listen_comm_id);
+
+        Ok(())
+    }
+}
+
+impl Drop for BaguaNet {
+    fn drop(&mut self) {
+        // TODO: make shutdown global
+        self.trace_span_context.span().end();
+        opentelemetry::global::shutdown_tracer_provider();
+    }
+}

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -667,7 +667,7 @@ impl interface::Net for BaguaNet {
 
     fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
         self.test_count += 1;
-        if self.test_count % 100000 == 0 {
+        if self.test_count % 1000000 == 0 {
             let send_request_count = self
                 .socket_request_map
                 .iter()

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -564,6 +564,7 @@ impl interface::Net for BaguaNet {
         self.tokio_rt.spawn(async move {
             let mut ctrl_stream = tokio::net::TcpStream::from_std(ctrl_stream).unwrap();
             ctrl_stream.set_nodelay(true).unwrap();
+            let mut log_count = 0;
             loop {
                 let (data, state) = match msg_receiver.recv().await {
                     Some(it) => it,
@@ -578,6 +579,16 @@ impl interface::Net for BaguaNet {
                         break;
                     }
                 };
+
+                log_count += 1;
+                if log_count % 100000 == 0 {
+                    println!(
+                        "local={}, peer={}",
+                        ctrl_stream.local_addr().unwrap(),
+                        ctrl_stream.peer_addr().unwrap()
+                    );
+                }
+
                 tracing::debug!(
                     "{:?} recv target_nbytes={}",
                     ctrl_stream.local_addr(),
@@ -666,31 +677,31 @@ impl interface::Net for BaguaNet {
     }
 
     fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
-        self.test_count += 1;
-        if self.test_count % 1000000 == 0 {
-            let send_request_count = self
-                .socket_request_map
-                .iter()
-                .filter(|(_, x)| match x {
-                    SocketRequest::SendRequest(_) => true,
-                    _ => false,
-                })
-                .count();
-            let recv_request_count = self
-                .socket_request_map
-                .iter()
-                .filter(|(_, x)| match x {
-                    SocketRequest::RecvRequest(_) => true,
-                    _ => false,
-                })
-                .count();
-            println!(
-                "hold_request={}, send={}, recv={}",
-                self.socket_request_map.len(),
-                send_request_count,
-                recv_request_count
-            );
-        }
+        // self.test_count += 1;
+        // if self.test_count % 10000000 == 0 {
+        //     let send_request_count = self
+        //         .socket_request_map
+        //         .iter()
+        //         .filter(|(_, x)| match x {
+        //             SocketRequest::SendRequest(_) => true,
+        //             _ => false,
+        //         })
+        //         .count();
+        //     let recv_request_count = self
+        //         .socket_request_map
+        //         .iter()
+        //         .filter(|(_, x)| match x {
+        //             SocketRequest::RecvRequest(_) => true,
+        //             _ => false,
+        //         })
+        //         .count();
+        //     println!(
+        //         "hold_request={}, send={}, recv={}",
+        //         self.socket_request_map.len(),
+        //         send_request_count,
+        //         recv_request_count
+        //     );
+        // }
 
         *self.state.request_count.lock().unwrap() = self.socket_request_map.len();
         let request = self.socket_request_map.get_mut(&request_id).unwrap();

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -667,23 +667,23 @@ impl interface::Net for BaguaNet {
 
     fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
         self.test_count += 1;
-        let send_request_count = self
-            .socket_request_map
-            .iter()
-            .filter(|(_, x)| match x {
-                SocketRequest::SendRequest(_) => true,
-                _ => false,
-            })
-            .count();
-        let recv_request_count = self
-            .socket_request_map
-            .iter()
-            .filter(|(_, x)| match x {
-                SocketRequest::RecvRequest(_) => true,
-                _ => false,
-            })
-            .count();
-        if self.test_count % 10000 == 0 {
+        if self.test_count % 100000 == 0 {
+            let send_request_count = self
+                .socket_request_map
+                .iter()
+                .filter(|(_, x)| match x {
+                    SocketRequest::SendRequest(_) => true,
+                    _ => false,
+                })
+                .count();
+            let recv_request_count = self
+                .socket_request_map
+                .iter()
+                .filter(|(_, x)| match x {
+                    SocketRequest::RecvRequest(_) => true,
+                    _ => false,
+                })
+                .count();
             println!(
                 "hold_request={}, send={}, recv={}",
                 self.socket_request_map.len(),

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -668,7 +668,7 @@ impl interface::Net for BaguaNet {
     fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
         self.test_count += 1;
         if self.test_count % 10000 == 0 {
-            println!("hold_request={}", socket_request_map.len());
+            println!("hold_request={}", self.socket_request_map.len());
         }
 
         *self.state.request_count.lock().unwrap() = self.socket_request_map.len();

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -101,7 +101,6 @@ pub struct BaguaNet {
 impl BaguaNet {
     const DEFAULT_SOCKET_MAX_COMMS: i32 = 65536;
     const DEFAULT_LISTEN_BACKLOG: i32 = 16384;
-    const DEFAULT_N_CONTROL_STREAM: i32 = 2;
 
     pub fn new() -> Result<BaguaNet, BaguaNetError> {
         let rank: i32 = std::env::var("RANK")

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -580,14 +580,14 @@ impl interface::Net for BaguaNet {
                     }
                 };
 
-                log_count += 1;
-                if log_count % 1000 == 0 {
-                    println!(
-                        "local={}, peer={}",
-                        ctrl_stream.local_addr().unwrap(),
-                        ctrl_stream.peer_addr().unwrap()
-                    );
-                }
+                // log_count += 1;
+                // if log_count % 1000 == 0 {
+                //     println!(
+                //         "local={}, peer={}",
+                //         ctrl_stream.local_addr().unwrap(),
+                //         ctrl_stream.peer_addr().unwrap()
+                //     );
+                // }
 
                 tracing::debug!(
                     "{:?} recv target_nbytes={}",

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -97,6 +97,7 @@ pub struct BaguaNet {
     nstreams: usize,
     min_chunksize: usize,
     tokio_rt: tokio::runtime::Runtime,
+    test_count: usize,
 }
 
 impl BaguaNet {
@@ -266,6 +267,7 @@ impl BaguaNet {
                 .parse()
                 .unwrap(),
             tokio_rt: tokio_rt,
+            test_count: 0,
         })
     }
 }
@@ -664,6 +666,11 @@ impl interface::Net for BaguaNet {
     }
 
     fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
+        self.test_count += 1;
+        if self.test_count % 10000 == 0 {
+            println!("hold_request={}", socket_request_map.len());
+        }
+
         *self.state.request_count.lock().unwrap() = self.socket_request_map.len();
         let request = self.socket_request_map.get_mut(&request_id).unwrap();
         let ret = match request {

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -564,7 +564,6 @@ impl interface::Net for BaguaNet {
         self.tokio_rt.spawn(async move {
             let mut ctrl_stream = tokio::net::TcpStream::from_std(ctrl_stream).unwrap();
             ctrl_stream.set_nodelay(true).unwrap();
-            let mut log_count = 0;
             loop {
                 let (data, state) = match msg_receiver.recv().await {
                     Some(it) => it,
@@ -579,15 +578,6 @@ impl interface::Net for BaguaNet {
                         break;
                     }
                 };
-
-                // log_count += 1;
-                // if log_count % 1000 == 0 {
-                //     println!(
-                //         "local={}, peer={}",
-                //         ctrl_stream.local_addr().unwrap(),
-                //         ctrl_stream.peer_addr().unwrap()
-                //     );
-                // }
 
                 tracing::debug!(
                     "{:?} recv target_nbytes={}",
@@ -677,32 +667,6 @@ impl interface::Net for BaguaNet {
     }
 
     fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
-        // self.test_count += 1;
-        // if self.test_count % 10000000 == 0 {
-        //     let send_request_count = self
-        //         .socket_request_map
-        //         .iter()
-        //         .filter(|(_, x)| match x {
-        //             SocketRequest::SendRequest(_) => true,
-        //             _ => false,
-        //         })
-        //         .count();
-        //     let recv_request_count = self
-        //         .socket_request_map
-        //         .iter()
-        //         .filter(|(_, x)| match x {
-        //             SocketRequest::RecvRequest(_) => true,
-        //             _ => false,
-        //         })
-        //         .count();
-        //     println!(
-        //         "hold_request={}, send={}, recv={}",
-        //         self.socket_request_map.len(),
-        //         send_request_count,
-        //         recv_request_count
-        //     );
-        // }
-
         *self.state.request_count.lock().unwrap() = self.socket_request_map.len();
         let request = self.socket_request_map.get_mut(&request_id).unwrap();
         let ret = match request {

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -224,6 +224,15 @@ impl BaguaNet {
             }),
         });
 
+        let tokio_rt = match std::env::var("BAGUA_NET_TOKIO_WORKER_THREADS") {
+            Ok(nworker_thread) => tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(nworker_thread.parse().unwrap())
+                .enable_all()
+                .build()
+                .unwrap(),
+            Err(_) => tokio::runtime::Runtime::new().unwrap(),
+        };
+
         Ok(Self {
             socket_devs: utils::find_interfaces(),
             listen_comm_next_id: 0,
@@ -243,19 +252,10 @@ impl BaguaNet {
                 .parse()
                 .unwrap(),
             min_chunksize: std::env::var("BAGUA_NET_MIN_CHUNKSIZE")
-                .unwrap_or("65536".to_owned())
+                .unwrap_or("131072".to_owned())
                 .parse()
                 .unwrap(),
-            tokio_rt: tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(
-                    std::env::var("BAGUA_NET_TOKIO_WORKER_THREADS")
-                        .unwrap_or("2".to_owned())
-                        .parse()
-                        .unwrap(),
-                )
-                .enable_all()
-                .build()
-                .unwrap(),
+            tokio_rt: tokio_rt,
         })
     }
 }

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -91,13 +91,11 @@ pub struct BaguaNet {
     pub socket_request_next_id: usize,
     pub socket_request_map: HashMap<SocketRequestID, SocketRequest>,
     pub trace_span_context: opentelemetry::Context,
-    pub trace_on_flag: bool,
     pub rank: i32,
     state: Arc<AppState>,
     nstreams: usize,
     min_chunksize: usize,
     tokio_rt: tokio::runtime::Runtime,
-    test_count: usize,
 }
 
 impl BaguaNet {
@@ -256,18 +254,16 @@ impl BaguaNet {
             socket_request_map: Default::default(),
             trace_span_context: opentelemetry::Context::current_with_span(span),
             rank: rank,
-            trace_on_flag: rank < 8,
             state: state,
             nstreams: std::env::var("BAGUA_NET_NSTREAMS")
                 .unwrap_or("2".to_owned())
                 .parse()
                 .unwrap(),
             min_chunksize: std::env::var("BAGUA_NET_MIN_CHUNKSIZE")
-                .unwrap_or("131072".to_owned())
+                .unwrap_or("65535".to_owned())
                 .parse()
                 .unwrap(),
             tokio_rt: tokio_rt,
-            test_count: 0,
         })
     }
 }

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -581,7 +581,7 @@ impl interface::Net for BaguaNet {
                 };
 
                 log_count += 1;
-                if log_count % 100000 == 0 {
+                if log_count % 1000 == 0 {
                     println!(
                         "local={}, peer={}",
                         ctrl_stream.local_addr().unwrap(),

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -667,8 +667,29 @@ impl interface::Net for BaguaNet {
 
     fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError> {
         self.test_count += 1;
+        let send_request_count = self
+            .socket_request_map
+            .iter()
+            .filter(|(_, x)| match x {
+                SocketRequest::SendRequest(_) => true,
+                _ => false,
+            })
+            .count();
+        let recv_request_count = self
+            .socket_request_map
+            .iter()
+            .filter(|(_, x)| match x {
+                SocketRequest::RecvRequest(_) => true,
+                _ => false,
+            })
+            .count();
         if self.test_count % 10000 == 0 {
-            println!("hold_request={}", self.socket_request_map.len());
+            println!(
+                "hold_request={}, send={}, recv={}",
+                self.socket_request_map.len(),
+                send_request_count,
+                recv_request_count
+            );
         }
 
         *self.state.request_count.lock().unwrap() = self.socket_request_map.len();

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "async")]
-
 use crate::interface;
 use crate::interface::{
     BaguaNetError, NCCLNetProperties, Net, SocketHandle, SocketListenCommID, SocketRecvCommID,

--- a/src/implement/tokio_backend.rs
+++ b/src/implement/tokio_backend.rs
@@ -429,7 +429,7 @@ impl Net for BaguaNet {
             ctrl_stream.peer_addr()
         );
 
-        let (msg_sender, mut msg_receiver) = flume::unbounded();
+        let (msg_sender, msg_receiver) = flume::unbounded();
         let id = self.send_comm_next_id;
         self.send_comm_next_id += 1;
         let send_comm = SocketSendComm {
@@ -458,7 +458,7 @@ impl Net for BaguaNet {
                     data.len()
                 );
 
-                datapass_sender.send((data, state)).unwrap();
+                datapass_sender.send_async((data, state)).await.unwrap();
             }
         });
         self.send_comm_map.insert(id, send_comm);
@@ -542,7 +542,7 @@ impl Net for BaguaNet {
             }
         });
 
-        let (msg_sender, mut msg_receiver) = flume::unbounded();
+        let (msg_sender, msg_receiver) = flume::unbounded();
         let id = self.recv_comm_next_id;
         self.recv_comm_next_id += 1;
         let recv_comm = SocketRecvComm {
@@ -572,7 +572,8 @@ impl Net for BaguaNet {
                 );
 
                 datapass_sender
-                    .send((&mut data[..target_nbytes], state))
+                    .send_async((&mut data[..target_nbytes], state))
+                    .await
                     .unwrap();
             }
         });

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,74 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone)]
+pub enum BaguaNetError {
+    #[error("io error")]
+    IOError(String),
+    #[error("tcp error")]
+    TCPError(String),
+    #[error("inner error")]
+    InnerError(String),
+}
+
+#[derive(Debug)]
+pub struct NCCLNetProperties {
+    pub name: String,
+    pub pci_path: String,
+    pub guid: u64,
+    pub ptr_support: i32, // NCCL_PTR_HOST or NCCL_PTR_HOST|NCCL_PTR_CUDA
+    pub speed: i32,       // Port speed in Mbps.
+    pub port: i32,
+    pub max_comms: i32,
+}
+
+#[derive(Debug)]
+pub struct SocketHandle {
+    pub addr: nix::sys::socket::SockAddr,
+}
+
+pub type SocketListenCommID = usize;
+pub type SocketSendCommID = usize;
+pub type SocketRecvCommID = usize;
+pub type SocketRequestID = usize;
+
+pub trait Net {
+    fn devices(&self) -> Result<usize, BaguaNetError>;
+
+    fn get_properties(&self, dev_id: usize) -> Result<NCCLNetProperties, BaguaNetError>;
+
+    fn listen(
+        &mut self,
+        dev_id: usize,
+    ) -> Result<(SocketHandle, SocketListenCommID), BaguaNetError>;
+
+    fn connect(
+        &mut self,
+        _dev_id: usize,
+        socket_handle: SocketHandle,
+    ) -> Result<SocketSendCommID, BaguaNetError>;
+
+    fn accept(
+        &mut self,
+        listen_comm_id: SocketListenCommID,
+    ) -> Result<SocketRecvCommID, BaguaNetError>;
+
+    fn isend(
+        &mut self,
+        send_comm_id: SocketSendCommID,
+        data: &'static [u8],
+    ) -> Result<SocketRequestID, BaguaNetError>;
+
+    fn irecv(
+        &mut self,
+        recv_comm_id: SocketRecvCommID,
+        data: &'static mut [u8],
+    ) -> Result<SocketRequestID, BaguaNetError>;
+
+    fn test(&mut self, request_id: SocketRequestID) -> Result<(bool, usize), BaguaNetError>;
+
+    fn close_send(&mut self, send_comm_id: SocketSendCommID) -> Result<(), BaguaNetError>;
+
+    fn close_recv(&mut self, recv_comm_id: SocketRecvCommID) -> Result<(), BaguaNetError>;
+
+    fn close_listen(&mut self, listen_comm_id: SocketListenCommID) -> Result<(), BaguaNetError>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub struct BaguaNetC {
 #[no_mangle]
 pub extern "C" fn bagua_net_c_create() -> *mut BaguaNetC {
     let config = std::env::var("BAGUA_NET_IMPLEMENT")
-        .unwrap_or("TOKIO".to_owned())
+        .unwrap_or("BASIC".to_owned())
         .to_uppercase();
     let bagua_net: Box<dyn Net> = match &config[..] {
         "TOKIO" => Box::new(tokio_backend::BaguaNet::new().unwrap()),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -205,62 +205,6 @@ pub fn chunk_size(total: usize, min_chunksize: usize, expected_nchunks: usize) -
     chunk_size
 }
 
-/// Creates a `SockAddr` struct from libc's sockaddr.
-///
-/// Supports only the following address families: Unix, Inet (v4 & v6), Netlink and System.
-/// Returns None for unsupported families.
-///
-/// # Safety
-///
-/// unsafe because it takes a raw pointer as argument.  The caller must
-/// ensure that the pointer is valid.
-#[cfg(not(target_os = "fuchsia"))]
-pub(crate) unsafe fn from_libc_sockaddr(addr: *const libc::sockaddr) -> Option<SockAddr> {
-    if addr.is_null() {
-        None
-    } else {
-        match AddressFamily::from_i32(i32::from((*addr).sa_family)) {
-            Some(AddressFamily::Unix) => None,
-            Some(AddressFamily::Inet) => Some(SockAddr::Inet(InetAddr::V4(
-                *(addr as *const libc::sockaddr_in),
-            ))),
-            Some(AddressFamily::Inet6) => Some(SockAddr::Inet(InetAddr::V6(
-                *(addr as *const libc::sockaddr_in6),
-            ))),
-            // #[cfg(any(target_os = "android", target_os = "linux"))]
-            // Some(AddressFamily::Netlink) => Some(SockAddr::Netlink(
-            //     NetlinkAddr(*(addr as *const libc::sockaddr_nl)))),
-            // #[cfg(any(target_os = "ios", target_os = "macos"))]
-            // Some(AddressFamily::System) => Some(SockAddr::SysControl(
-            //     SysControlAddr(*(addr as *const libc::sockaddr_ctl)))),
-            // #[cfg(any(target_os = "android", target_os = "linux"))]
-            // Some(AddressFamily::Packet) => Some(SockAddr::Link(
-            //     LinkAddr(*(addr as *const libc::sockaddr_ll)))),
-            // #[cfg(any(target_os = "dragonfly",
-            //             target_os = "freebsd",
-            //             target_os = "ios",
-            //             target_os = "macos",
-            //             target_os = "netbsd",
-            //             target_os = "illumos",
-            //             target_os = "openbsd"))]
-            // Some(AddressFamily::Link) => {
-            //     let ether_addr = LinkAddr(*(addr as *const libc::sockaddr_dl));
-            //     if ether_addr.is_empty() {
-            //         None
-            //     } else {
-            //         Some(SockAddr::Link(ether_addr))
-            //     }
-            // },
-            // #[cfg(any(target_os = "android", target_os = "linux"))]
-            // Some(AddressFamily::Vsock) => Some(SockAddr::Vsock(
-            //     VsockAddr(*(addr as *const libc::sockaddr_vm)))),
-            // Other address families are currently not supported and simply yield a None
-            // entry instead of a proper conversion to a `SockAddr`.
-            Some(_) | None => None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -144,7 +144,7 @@ pub fn nonblocking_write_all(stream: &mut std::net::TcpStream, mut buf: &[u8]) -
                     || e.kind() == io::ErrorKind::WouldBlock => {}
             Err(e) => return Err(e),
         }
-        // std::thread::yield_now();
+        std::thread::yield_now();
     }
     Ok(())
 }
@@ -165,7 +165,7 @@ pub fn nonblocking_read_exact(
                     || e.kind() == io::ErrorKind::WouldBlock => {}
             Err(e) => return Err(e),
         }
-        // std::thread::yield_now();
+        std::thread::yield_now();
     }
     if !buf.is_empty() {
         Err(io::Error::new(


### PR DESCRIPTION
This commit contains two features and one bug fix.

Features:

1. Support tokio backend for better performance in send / recv hybrid communication scenarios.
2. Improved packet split method `utils::chunk_size`. This method can divide the communication packet into multiple small packets of equal size as required, and the packet body is not less than the minimum limit.

Bug fix:
1. In our implementation, one p2p communication corresponds to multiple TCP links. When establishing the link, there was a false assumption that the order in which the [server accepts](https://github.com/BaguaSys/bagua-net/blob/v0.1.0/src/bagua_net.rs#L452) is the same as the order in which the [client initiates the connect](https://github.com/BaguaSys/bagua-net/blob/v0.1.0/src/bagua_net.rs#L337). Because `accept` function is take a connection from the pool of tcp links, Instead of one-to-one correspondence with connection. Any way, I fixed this bug.